### PR TITLE
Remove inaccurate badge link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       env: JEKYLL_VERSION="~> 3.9"
     - rvm: *latest_ruby
       env: JEKYLL_VERSION="~> 4.2"
+
 before_install:
   - gem update --system
   - gem install bundler

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Jekyll plugin to generate an Atom (RSS-like) feed of your Jekyll posts
 
-[![Build Status](https://travis-ci.com/emmasax4/jekyll-feed.svg?branch=main)](https://travis-ci.com/emmasax4/jekyll-feed) [![Gem Version](https://badge.fury.io/rb/jekyll-feed.svg)](https://badge.fury.io/rb/jekyll-feed)
+[![Build Status](https://travis-ci.com/emmasax4/jekyll-feed.svg?branch=main)](https://travis-ci.com/emmasax4/jekyll-feed)
 
 ## Installation
 


### PR DESCRIPTION
Remove the badge on the README that shows the version of the gem when I forked this gem. On my fork, I won't use the tags anymore, so there's no use having them around.