### PR TITLE
Use a shorter – when showing blog posts with subtitles

### DIFF
--- a/lib/jekyll-feed/feed.xml
+++ b/lib/jekyll-feed/feed.xml
@@ -78,7 +78,7 @@
   {% for post in posts limit: posts_limit %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>
       {% if post.subtitle %}
-        {% assign post_title = post.title | append: " — " | append: post.subtitle %}
+        {% assign post_title = post.title | append: " – " | append: post.subtitle %}
       {% else %}
         {% assign post_title = post.title %}
       {% endif %}

--- a/spec/jekyll-feed_spec.rb
+++ b/spec/jekyll-feed_spec.rb
@@ -302,7 +302,7 @@ describe(JekyllFeed) do
 
   context "with a subtitle" do
     it "should contain the title and subtitle with an arrow" do
-      expect(contents).to match "This is the Title — This is the Subtitle"
+      expect(contents).to match "This is the Title – This is the Subtitle"
     end
   end
 


### PR DESCRIPTION
Use a shorter – when writing blog posts with subtitles instead of —. This will match some of the changes made in https://github.com/emmahsax/jekyll-seo-tag/pull/12/files#diff-d3649b622acf712d7814682c0f3177f5935b592ab9cde36b4ec99b63ca845081R73.