### PR TITLE
Update gemspec with new gems that need to be added

### DIFF
--- a/jekyll-feed.gemspec
+++ b/jekyll-feed.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
+  spec.add_dependency "base64", "~> 0.2"
+  spec.add_dependency "bigdecimal", "~> 3.1"
+  spec.add_dependency "csv", "~> 3.2"
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
Without adding these gems, we now get this warning:
```
/Users/emmasax/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/jekyll-4.3.3/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of jekyll-4.3.3 to add csv into its gemspec.
/Users/emmasax/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of safe_yaml-1.0.5 to add base64 into its gemspec.
/Users/emmasax/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/liquid-4.0.4/lib/liquid/standardfilters.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of liquid-4.0.4 to add bigdecimal into its gemspec.
```